### PR TITLE
feat: npm v7 support - version2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # vim-efm-langserver-settings
 
-version 1: support npm before v7.
+version 2: support npm v7 or later.
+When you using with npm before v7, use version 1.
 
 ## detail
 

--- a/config/efm-langserver/config.yaml
+++ b/config/efm-langserver/config.yaml
@@ -228,7 +228,7 @@ tools:
       - '%tRROR %f:%l %m'
 
   textlint-lint: &textlint-lint
-    lint-command: 'npx --no-install textlint -f unix --stdin --stdin-filename ${INPUT}'
+    lint-command: 'npx --no textlint -f unix --stdin --stdin-filename ${INPUT}'
     lint-ignore-exit-code: true
     lint-stdin: true
     lint-formats:
@@ -237,7 +237,7 @@ tools:
       - .textlintrc
 
   eslint-lint: &eslint-lint
-    lint-command: 'npx --no-install eslint -f unix --stdin --stdin-filename ${INPUT}'
+    lint-command: 'npx --no eslint -f unix --stdin --stdin-filename ${INPUT}'
     lint-ignore-exit-code: true
     lint-stdin: true
     root-markers:
@@ -248,7 +248,7 @@ tools:
       - .eslintrc.json
 
   eslint-format: &eslint-format
-    format-command: 'npx --no-install eslint --fix ${INPUT}'
+    format-command: 'npx --no eslint --fix ${INPUT}'
     format-stdin: false
     root-markers:
       - package.json
@@ -258,7 +258,7 @@ tools:
       - .eslintrc.json
 
   stylelint-lint: &stylelint-lint
-    lint-command: 'npx --no-install stylelint --formatter unix --stdin --stdin-filename ${INPUT}'
+    lint-command: 'npx --no stylelint --formatter unix --stdin --stdin-filename ${INPUT}'
     lint-ignore-exit-code: false
     lint-stdin: true
     lint-formats:
@@ -268,7 +268,7 @@ tools:
       - .stylelintrc.json
 
   htmllint-lint: &htmllint-lint
-    lint-command: 'npx --no-install htmllint ${INPUT}'
+    lint-command: 'npx --no htmllint ${INPUT}'
     lint-stdin: false
     lint-formats:
       - '%f: line %l, col %c, %m'
@@ -276,7 +276,7 @@ tools:
       - .htmllintrc
 
   prettier-format: &prettier-format
-    format-command: 'npx --no-install prettier ${INPUT}'
+    format-command: 'npx --no prettier ${INPUT}'
     format-stdin: false
 
   excitetranslate-hover: &excitetranslate-hover

--- a/doc/vim-efm-langserver-settings.jax
+++ b/doc/vim-efm-langserver-settings.jax
@@ -72,7 +72,8 @@ https://github.com/tsuyoshicho/vim-efm-langserver-settings.vim
 ------------------------------------------------------------------------------
 バージョン				  *vim-efm-langserver-settings-version*
 
-バージョン 1: npm v7以前をサポートします。
+バージョン 2: npm v7もしくはそれ以降をサポートします。
+npm v7以前とともに使う場合は、バージョン 1を使ってください。
 
 ==============================================================================
 使い方					*vim-efm-langserver-settings-usage*

--- a/doc/vim-efm-langserver-settings.txt
+++ b/doc/vim-efm-langserver-settings.txt
@@ -73,7 +73,8 @@ https://github.com/tsuyoshicho/vim-efm-langserver-settings.vim
 ------------------------------------------------------------------------------
 VERSION					  *vim-efm-langserver-settings-version*
 
-version 1: support npm before v7.
+version 2: support npm v7 or later.
+When you using with npm before v7, use version 1.
 
 ==============================================================================
 USAGE					*vim-efm-langserver-settings-usage*


### PR DESCRIPTION
- [Presenting v7\.0\.0 of the npm CLI \- The GitHub Blog](https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/)
- [npm v7の主な変更点まとめ \| watilde's blog](https://blog.watilde.com/2020/10/14/npm-v7%E3%81%AE%E4%B8%BB%E3%81%AA%E5%A4%89%E6%9B%B4%E7%82%B9%E3%81%BE%E3%81%A8%E3%82%81/)

> 正式なGAは来週の火曜日
2020/10/20

(マージ後 `release/v2` を作るのはなし、v3が出るまでは不要とする)