### PR TITLE
fix: Add lint-formats '%f:%l:%c %m' for markdownlint

### DIFF
--- a/config/efm-langserver/config.yaml
+++ b/config/efm-langserver/config.yaml
@@ -127,6 +127,7 @@ tools:
     lint-command: 'markdownlint --stdin'
     lint-stdin: true
     lint-formats:
+      - '%f:%l:%c %m'
       - '%f:%l %m'
       - '%f: %l: %m'
     commands:


### PR DESCRIPTION
## related issue

close #100 

## Fix or Add this PR/このプルリクエストでやったこと

- Add lint-format '%F:%l:%c %m' to markdownlint lint-formats


## Not fix or add this PR/このプルリクエストでやらなかったこと

## Pros and Cons/メリットとデメリット

## Test/動作確認

チェックボックス式にし、確認後チェックする。

- [x] MD034 (rule with column number) is displayed correctly

