### PR TITLE
fix: textlint efm not catch message

### DIFF
--- a/config/efm-langserver/config.yaml
+++ b/config/efm-langserver/config.yaml
@@ -253,6 +253,8 @@ tools:
     lint-stdin: true
     lint-formats:
       - '%f:%l:%c: %m [%trror/%r]'
+      - '%f:%l:%c: 【%r】 %m'
+      - '%f:%l:%c: %m'
     root-markers:
       - .textlintrc
     commands:


### PR DESCRIPTION
Now, support only `%f:%l:%c: %m [Error/...]`

Fix support

- `%f:%l:%c: %m [Error/...]`
- `%f:%l:%c: 【...】 %m`
- `%f:%l:%c: %m` (any)