### PR TITLE
fix: add textlint/multiline support

### DIFF
--- a/config/efm-langserver/config.yaml
+++ b/config/efm-langserver/config.yaml
@@ -254,7 +254,9 @@ tools:
     lint-formats:
       - '%f:%l:%c: %m [%trror/%r]'
       - '%f:%l:%c: 【%r】 %m'
-      - '%f:%l:%c: %m'
+      - '%E%f:%l:%c: %m'
+      - '%Z%m [%trror/%r]'
+      - '%C%m'
     root-markers:
       - .textlintrc
     commands:


### PR DESCRIPTION
## related issue

close #121 

## Fix or Add this PR/このプルリクエストでやったこと

- add multiline errorformat add

## Not fix or add this PR/このプルリクエストでやらなかったこと

- remove general message support

## Pros and Cons/メリットとデメリット

- quickfix lookup multiline message

## Test/動作確認

- [x] use errorformat playground test

