### PR TITLE
fix: cppcheck error for many ifdef

### DIFF
--- a/config/efm-langserver/config.yaml
+++ b/config/efm-langserver/config.yaml
@@ -77,7 +77,7 @@ commands:
 # linter,formatter setting
 tools:
   cppcheck-lint: &cppcheck-lint
-    lint-command: 'cppcheck --enable=style --error-exitcode=1 ${INPUT}'
+    lint-command: 'cppcheck --quiet --force --enable=style --error-exitcode=1 ${INPUT}'
     lint-stdin: false
     lint-formats:
       - '%f:%l:%c: %m'


### PR DESCRIPTION
related.

https://github.com/prabirshrestha/vim-lsp/issues/1018

The cppcheck default report ifdef too many error.
This error line:-1 and throw no line in vim-lsp.

Fix: cppcheck add --force and --quiet